### PR TITLE
refactor es5 and es6 react component parsers

### DIFF
--- a/src/reactParser.js
+++ b/src/reactParser.js
@@ -41,22 +41,25 @@ function getES5ReactComponents() {
       }
     },
     JSXElement: function (node) {
-      var jsxComponentsArr = node
-        .children
-        .filter(jsx => {
-          return jsx.type === "JSXElement" &&
-            htmlElements.indexOf(jsx.openingElement.name.name) < 0
-        });
-      for (let prop in output) {
-        if (output[prop] === currVariableName) {
-          output.children = jsxComponentsArr.map(jsx => {
-            return { name: jsx.openingElement.name.name };
-          });
-        }
-      }
+      output.children = getChildJSXElements(node);
     },
   });
   return output;
+}
+
+function getChildJSXElements (node) {
+  if (node.children.length === 0) return [];
+  var childJsxComponentsArr = node
+    .children
+    .filter(jsx => jsx.type === "JSXElement" 
+    && htmlElements.indexOf(jsx.openingElement.name.name) < 0);
+  return childJsxComponentsArr
+    .map(child => {
+      return {
+        name: child.openingElement.name.name,
+        children: getChildJSXElements(child),
+      };
+    })
 }
 
 function isReactComponent (node) {

--- a/src/test/reactParserTest.js
+++ b/src/test/reactParserTest.js
@@ -65,9 +65,40 @@ describe('ESTree AST Parser Tests', function() {
       class Main extends Component {}
     `;
 
+    let es6NestedComponents = `
+      class Main extends Component {
+        render () {
+          return <div>
+            <SearchBar />
+            <div>Testing</div>
+            <SearchResults>
+              <Result />
+              <Result />
+            </SearchResults>
+          </div>
+        }
+      }
+    `;
+
     it('should return object with name of top-level components in js file using es6', function() {
       jsToAst(es6Components);
       expect(getES6ReactComponents()).to.deep.equal({ name: 'Main' });
+    });
+
+    it('should return object with \'Main\' as top-level component with nested children components', function() {
+      jsToAst(es6NestedComponents);
+      expect(getES6ReactComponents()).to.deep.equal({ 
+        name: 'Main',
+        children: [
+          { name: 'SearchBar', children: [] }, 
+          { name: 'SearchResults',
+            children: [
+              { name: 'Result', children: [] }, 
+              { name: 'Result', children: [] }
+            ]
+          }
+        ],
+      });
     });
   });
 });

--- a/src/test/reactParserTest.js
+++ b/src/test/reactParserTest.js
@@ -23,9 +23,11 @@ describe('ESTree AST Parser Tests', function() {
         render: function() {
           return <div>
             <SearchBar />
-            <div>
-              Testing
-            </div>
+            <div>Testing</div>
+            <SearchResults>
+              <Result />
+              <Result />
+            </SearchResults>
           </div>
         }
       });
@@ -44,7 +46,15 @@ describe('ESTree AST Parser Tests', function() {
       jsToAst(es5NestedComponents);
       expect(getES5ReactComponents()).to.deep.equal({ 
         name: 'Main',
-        children: [{ name: 'SearchBar'}],
+        children: [
+          { name: 'SearchBar', children: [] }, 
+          { name: 'SearchResults',
+            children: [
+              { name: 'Result', children: [] }, 
+              { name: 'Result', children: [] }
+            ]
+          }
+        ],
       });
     });
   });


### PR DESCRIPTION
- remove unnecessary visitor checks at specific statements when recursing with es5 parser
- refactored es6 parser to handle nested jsx component hierarchies