### PR TITLE
fix d3DataBuilder bug parsing stateless functional components

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -2,7 +2,7 @@ module.exports = {
   htmlElements: [
     'a', 'article', 'audio', 'b', 'body', 'br', 'button', 'canvas', 'caption',
     'code', 'dialog', 'div', 'dl', 'dt', 'em', 'embed', 'font', 'footer', 'form',
-    'frame', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'html', 'i', 'iframe', 'img',
+    'frame', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'html', 'hr', 'i', 'iframe', 'img',
     'input', 'kbd', 'label', 'legend', 'li', 'link', 'main', 'map', 'noscript',
     'object', 'ol', 'option', 'p', 'param', 'pre', 'progress', 'q', 'rb', 'rt',
     'ruby', 's', 'samp', 'script', 'section', 'select', 'small', 'source', 'span',

--- a/src/d3DataBuilder.js
+++ b/src/d3DataBuilder.js
@@ -20,13 +20,14 @@ function d3DataBuilder(obj) {
     if (reactParser.componentChecker(obj[key])) formatted[key] = reactParser.getES6ReactComponents(obj[key]) 
     else {
       let es5obj = reactParser.getES5ReactComponents(obj[key]);
-      if (es5obj.name !== '') formatted[key] = es5obj; //if the name is defined, it is an es5 component
-      else formatted[key] = reactParser.getStatelessFunctionalComponents(obj[key]); //else it is a stateless functional component
+      formatted[key] = es5obj; //if the name is defined, it is an es5 component
+      formatted[key].name = key;
+      // else formatted[key] = reactParser.getStatelessFunctionalComponents(obj[key]); //else it is a stateless functional component
     }
   }
 
   let result = cloneDeep(formatted[ENTRY]);
-
+  
 // recursive function to concat and build the d3 object
   function treeAddition(node) {
     if (!node.children) throw new Error('Invalid Node! Something went wrong with the parsing (no children array)')


### PR DESCRIPTION
- fix name parse when parsing stateless functional components
- add 'hr' HTML element tag to constants list of elements to filter out